### PR TITLE
Update localize.js

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -68,7 +68,7 @@ angular.module('localization', [])
                 // request the resource file
                 $http({ method:"GET", url:url, cache:false }).success(localize.successCallback).error(function () {
                     // the request failed set the url to the default resource file
-                    var url = '/i18n/resources-locale_default.js';
+                    var url = 'i18n/resources-locale_default.js';
                     // request the default resource file
                     $http({ method:"GET", url:url, cache:false }).success(localize.successCallback);
                 });


### PR DESCRIPTION
I'm getting error 404 not found when deploying my webapp into a folder (site.local/myapp/#/) and localize.js search into site.local/i18n/ for files. I have solved removing the '/' from the requesting url. Now it should work for every locations.
