### PR TITLE
Ability to configure a list of available languages and default language

### DIFF
--- a/tests/specs/localization-service-unit-test.js
+++ b/tests/specs/localization-service-unit-test.js
@@ -1,9 +1,43 @@
+describe('localization configuration', function () {
+    var service;
+
+    beforeEach(module('localization', function(localizeProvider) {
+        localizeProvider.languages = ['fr', 'es'];
+        localizeProvider.defaultLanguage = 'fr';
+    }));
+
+    beforeEach(inject(function (localize) {
+        service = localize;
+    }));
+
+    it('should set a language', function() {
+        service.setLanguage('fr');
+
+        expect(service.language).toBe('fr');
+    });
+
+    it('should fallback to a main language', function() {
+        service.setLanguage('fr-fr');
+
+        expect(service.language).toBe('fr');
+    });
+
+    it('should fallback to a default language', function() {
+        service.setLanguage('it');
+
+        expect(service.language).toBe('fr');
+    });
+});
+
 describe('localization service', function () {
     var rootScope;
     var $httpBackend;
     var injector;
 
-    beforeEach(module('localization'));
+    beforeEach(module('localization', function(localizeProvider) {
+        localizeProvider.languages = ['en-US', 'es'];
+        localizeProvider.defaultLanguage = 'en-US';
+    }));
 
     beforeEach(inject(function ($injector) {
         injector = $injector;
@@ -72,123 +106,6 @@ describe('localization service', function () {
         ]);
 
         var service = injector.get('localize');
-
-        $httpBackend.flush();
-    });
-
-    it('should request default resource file on request error', function () {
-        $httpBackend.whenGET('/i18n/resources-locale_en-pl.js').respond(400, { "Message": "It's broke" });
-        $httpBackend.whenGET('/i18n/resources-locale_en-US.js').
-            respond([
-                {
-                    "key":"_HomeTitle_",
-                    "value":"Welcome to Brew Everywhere!",
-                    "description":"Home page greeting text"
-                },
-                {
-                    "key":"_HomeText_",
-                    "value":"The web site that allows you to manage all your brewing in one place. Brew Everywhere allows you to access your recipes, equipment, brewing inventory and brewing calendar from anywhere on any device.",
-                    "description":"Home page introductory text"
-                },
-                {
-                    "key":"_HomeSlogan_",
-                    "value":"We'd like to think \"You don't need an app for that!\"",
-                    "description":"Home page slogan text"
-                },
-                {
-                    "key":"_TopRecipeTitle_",
-                    "value":"Highest Rated Recipes",
-                    "description":"Top Rated Recipe Title"
-                },
-                {
-                    "key":"_ViewDetails_Button_Title_",
-                    "value":"View details &raquo;",
-                    "description":"View Details Button Title Text"
-                },
-                {
-                    "key":"_TopContributorTitle_",
-                    "value":"Highest Contributors",
-                    "description":"Top Contributors Title text"
-                },
-                {
-                    "key":"_WhatsFermentingTitle_",
-                    "value":"What's Fermenting",
-                    "description":"What's Fermenting section Title text"
-                },
-                {
-                    "key":"_MyRecipesTitle_",
-                    "value":"My Recipes",
-                    "description":"My Recipes Section Title text"
-                },
-                {
-                    "key":"_MyCalendarTitle_",
-                    "value":"My Calender",
-                    "description":"My Calendar Section Title text"
-                },
-                {
-                    "key":"_MyInventoryTitle_",
-                    "value":"My Inventory",
-                    "description":"My Inventory Section Title text"
-                }
-            ]);
-
-        $httpBackend.expectGET('/i18n/resources-locale_default.js').
-            respond([
-            {
-                "key":"_HomeTitle_",
-                "value":"Welcome to Brew Everywhere!",
-                "description":"Home page greeting text"
-            },
-            {
-                "key":"_HomeText_",
-                "value":"The web site that allows you to manage all your brewing in one place. Brew Everywhere allows you to access your recipes, equipment, brewing inventory and brewing calendar from anywhere on any device.",
-                "description":"Home page introductory text"
-            },
-            {
-                "key":"_HomeSlogan_",
-                "value":"We'd like to think \"You don't need an app for that!\"",
-                "description":"Home page slogan text"
-            },
-            {
-                "key":"_TopRecipeTitle_",
-                "value":"Highest Rated Recipes",
-                "description":"Top Rated Recipe Title"
-            },
-            {
-                "key":"_ViewDetails_Button_Title_",
-                "value":"View details &raquo;",
-                "description":"View Details Button Title Text"
-            },
-            {
-                "key":"_TopContributorTitle_",
-                "value":"Highest Contributors",
-                "description":"Top Contributors Title text"
-            },
-            {
-                "key":"_WhatsFermentingTitle_",
-                "value":"What's Fermenting",
-                "description":"What's Fermenting section Title text"
-            },
-            {
-                "key":"_MyRecipesTitle_",
-                "value":"My Recipes",
-                "description":"My Recipes Section Title text"
-            },
-            {
-                "key":"_MyCalendarTitle_",
-                "value":"My Calender",
-                "description":"My Calendar Section Title text"
-            },
-            {
-                "key":"_MyInventoryTitle_",
-                "value":"My Inventory",
-                "description":"My Inventory Section Title text"
-            }
-        ]);
-
-        var service = injector.get('localize');
-
-        service.setLanguage('en-pl');
 
         $httpBackend.flush();
     });
@@ -420,5 +337,20 @@ describe('localization service', function () {
 
         expect(rootScope.$broadcast).toHaveBeenCalled();
 
+    });
+
+    it('should return key if no value is available', function() {
+        $httpBackend.expectGET('/i18n/resources-locale_en-US.js').
+            respond([{
+                "key":"test",
+                "value":"win"
+            }]);
+
+        var service = injector.get('localize');
+
+        $httpBackend.flush();
+
+        expect(service.getLocalizedString('test')).toBe('win');
+        expect(service.getLocalizedString('foobar')).toBe('foobar');
     });
 });


### PR DESCRIPTION
I made a service to be able to configure a list of available languages instead of making a useless request to an unknow locale file. You can specify a default language and fallback to a main language if you don't want to manage regional languages.

You can specify :
localizeProvider.languages = ['en', 'en-US', 'en-EN', 'fr'];
localizeProvider.defaultLanguage = 'en-US'

So 'es' will fallback to 'en-US', 'fr-fr' will fallback to 'fr' and 'en-EN' will be ok.
