### PR TITLE
Removing leading slash for apps in subfolders

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -84,7 +84,7 @@ angular.module('localization', [])
                         // set language
                         localize.language = this.fallbackLanguage(lang);
                     }
-                    return '/i18n/resources-locale_' + localize.language + '.' + provider.ext;
+                    return 'i18n/resources-locale_' + localize.language + '.' + provider.ext;
                 },
 
                 // loads the language resource file from the server


### PR DESCRIPTION
http://mydomain/myapp was loading http://mydomain/i18n/resources-locale_lang.js instead of http://mydomain/myapp/i18n/resources-locale_lang.js
