### PR TITLE
Allow to display html in locales definitions

### DIFF
--- a/src/localize.js
+++ b/src/localize.js
@@ -144,7 +144,7 @@ angular.module('localization', [])
     .directive('i18n', ['localize', function(localize){
         var i18nDirective = {
             restrict:"EAC",
-            updateText:function(elm, token){
+            updateText:function(elm, token, html){
                 var values = token.split('|');
                 if (values.length >= 1) {
                     // construct the tag to insert into the element
@@ -158,18 +158,18 @@ angular.module('localization', [])
                             }
                         }
                         // insert the text into the element
-                        elm.text(tag);
+                        elm[html ? 'html':'text'](tag);
                     };
                 }
             },
 
             link:function (scope, elm, attrs) {
                 scope.$on('localizeResourcesUpdated', function() {
-                    i18nDirective.updateText(elm, attrs.i18n);
+                    i18nDirective.updateText(elm, attrs.i18n, angular.isDefined(attrs.i18nHtml));
                 });
 
                 attrs.$observe('i18n', function (value) {
-                    i18nDirective.updateText(elm, attrs.i18n);
+                    i18nDirective.updateText(elm, attrs.i18n, angular.isDefined(attrs.i18nHtml));
                 });
             }
         };

--- a/tests/specs/localization-directives-unit-test.js
+++ b/tests/specs/localization-directives-unit-test.js
@@ -51,6 +51,57 @@ describe('i18n directive', function() {
     });
 });
 
+describe('i18n directive with i18n-html', function() {
+    var elm1;
+    var elm2;
+    var scope;
+    var localize;
+
+    // load the localization code
+    beforeEach(module('localization'));
+
+    beforeEach(function () {
+
+        localize = {
+            getLocalizedString: function (value) {
+                if (value === 'TEST_ITEM1') {
+                    return 'This is a test <strong>response</strong>.';
+                } else {
+                    return '';
+                }
+            }
+        };
+
+        module('localization', function ($provide) {
+            $provide.value('localize', localize);
+        });
+    });
+
+    beforeEach(inject(function ($rootScope, $compile) {
+        // we might move this tpl into an html file as well...
+        elm1 = angular.element('<div data-i18n="TEST_ITEM1"></div>');
+
+        elm2 = angular.element('<div data-i18n="TEST_ITEM1" data-i18n-html></div>');
+
+        scope = $rootScope;
+        $compile(elm1)(scope);
+        $compile(elm2)(scope);
+        scope.$digest();
+    }));
+
+    it('should have html encoded content', function () {
+        var titles = elm1.html();
+
+        expect(titles).toBe('This is a test &lt;strong&gt;response&lt;/strong&gt;.');
+    });
+
+    it('should have html content', function () {
+        var titles = elm2.html();
+
+        expect(titles).toBe('This is a test <strong>response</strong>.');
+    });
+});
+
 describe('i18nAttr directive', function() {
     var elm;
     var multi;


### PR DESCRIPTION
You can chose to display the translation as html instead of text by adding `i18n-html` attribute to your element.
